### PR TITLE
upgrade multitool

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ jobs:
   SCS:
     runs-on: ubuntu-latest
     steps:     
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
+      # Required for security-code-scan/security-code-scan-results-action@v1
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '3.1.x'  
       
       - name: Set up projects
         uses: security-code-scan/security-code-scan-add-action@v1.2
@@ -36,7 +41,7 @@ jobs:
         uses: security-code-scan/security-code-scan-results-action@v1
         
       - name: Upload sarif	
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v3
 ```
 
 For .NET 4.x example see [FullDotNetWebApp demo repository](https://github.com/security-code-scan/FullDotNetWebApp).

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ runs:
     - name: Convert sarif
       shell: bash
       run: |
-        dotnet tool install --global Sarif.Multitool --version 2.3.10
+        dotnet tool install --global Sarif.Multitool --version 4.5.4
         outputDir="${{ inputs.sarif_directory }}"
         mkdir $outputDir
         

--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ runs:
         i=0
         for sarifFile in $(find ./ -name '*.sarif')
         do
-          sarif transform $sarifFile --output $sarifFile -f --sarif-output-version Current
+          sarif rewrite $sarifFile --output $sarifFile --sarif-output-version Current --log ForceOverwrite
           node convert.js $sarifFile $sarifFile
           mv $sarifFile $outputDir/$((i++)).sarif
         done


### PR DESCRIPTION
Dependency updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R30): Updated `actions/checkout` to version 4 and `github/codeql-action/upload-sarif` to version 3. Added `actions/setup-dotnet` to set up .NET version 3.1.x which is required for the multitool to run. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R44)
  - https://github.com/microsoft/sarif-sdk/issues/2766
  - https://github.com/microsoft/sarif-sdk/issues/2511

SARIF file handling improvements:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L17-R17): Updated `Sarif.Multitool` to version 4.5.4.
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L73-R73): Changed the command from `sarif transform` to `sarif rewrite` with additional parameters for SARIF file processing.